### PR TITLE
feature: keep empty rows support

### DIFF
--- a/src/RunReportConfiguration.php
+++ b/src/RunReportConfiguration.php
@@ -36,6 +36,8 @@ class RunReportConfiguration
 
     protected string $filterMethod = 'and_group';
 
+    protected bool $includeEmptyRows = false;
+
     public function setStartDate(string $startDate): static
     {
         $this->startDate = $startDate;
@@ -46,6 +48,13 @@ class RunReportConfiguration
     public function setEndDate(string $endDate): static
     {
         $this->endDate = $endDate;
+
+        return $this;
+    }
+
+    public function includeEmptyRows(bool $includeEmptyRows = true): static
+    {
+        $this->includeEmptyRows = $includeEmptyRows;
 
         return $this;
     }
@@ -243,6 +252,10 @@ class RunReportConfiguration
             'dimensionFilter' => $this->buildNativeDimensionFilters(),
             'metricFilter' => $this->buildNativeMetricFilters(),
         ];
+
+        if ($this->includeEmptyRows) {
+            $configuration['keepEmptyRows'] = true;
+        }
 
         if (! empty($this->orderByMetrics) || ! empty($this->orderByDimensions)) {
             $configuration['orderBys'] = $this->buildNativeOrderBy();

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -173,3 +173,28 @@ it('can generate orderBy from dimensions only', function () {
 
     expect($config['orderBys'])->not()->toBeEmpty();
 });
+
+it('includes empty rows when requested', function () {
+    $period = Period::months(1);
+
+    $config = (new RunReportConfiguration())
+        ->setDateRange($period)
+        ->addDimensions(['country', 'landingPage', 'date'])
+        ->addMetrics(['sessions'])
+        ->includeEmptyRows()
+        ->toGoogleObject();
+
+    expect($config['keepEmptyRows'])->toBeTrue();
+});
+
+it('does not include empty rows by default', function () {
+    $period = Period::months(1);
+
+    $config = (new RunReportConfiguration())
+        ->setDateRange($period)
+        ->addDimensions(['country', 'landingPage', 'date'])
+        ->addMetrics(['sessions'])
+        ->toGoogleObject();
+
+    expect($config)->not()->toHaveKey('keepEmptyRows');
+});


### PR DESCRIPTION
Adds ability to keep empty rows in reports, based on these docs:

https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport